### PR TITLE
[WIP] Compute score boards for bigger grids

### DIFF
--- a/test/battleship/game/scoreboard_test.go
+++ b/test/battleship/game/scoreboard_test.go
@@ -102,12 +102,96 @@ func TestGetScoreBoardWithObstacle(t *testing.T) {
 	displayScoreBoard(actual, computedShip, grid)
 }
 
+func TestGetScoreBoardWithBiggerGridWithoutObstacle(t *testing.T) {
+	grid, _ := game.NewGrid(10)
+
+	computedShip := game.Ship{2, []game.Cell{}}
+
+	cells := [][]int{
+		{2, 3, 3, 3, 3, 3, 3, 3, 3, 2},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{2, 3, 3, 3, 3, 3, 3, 3, 3, 2},
+	}
+
+	expected := &scoreboard.ScoreBoard{10, cells}
+
+	actual, _ := game.GetScoreBoard(grid, computedShip)
+
+	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid without obstacle"))
+	displayScoreBoard(actual, computedShip, grid)
+}
+
+func TestGetScoreBoardWithBiggerGridAndOneObstacle(t *testing.T) {
+	grid, _ := game.NewGrid(10)
+	ship := game.Ship{1, []game.Cell{{1, 2}}}
+	grid = game.AddShip(grid, ship)
+
+	computedShip := game.Ship{2, []game.Cell{}}
+
+	cells := [][]int{
+		{2, 3, 2, 3, 3, 3, 3, 3, 3, 2},
+		{3, 3, 0, 3, 4, 4, 4, 4, 4, 3},
+		{3, 4, 3, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{3, 4, 4, 4, 4, 4, 4, 4, 4, 3},
+		{2, 3, 3, 3, 3, 3, 3, 3, 3, 2},
+	}
+
+	expected := &scoreboard.ScoreBoard{10, cells}
+
+	actual, _ := game.GetScoreBoard(grid, computedShip)
+
+	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid with one obstacle"))
+	displayScoreBoard(actual, computedShip, grid)
+}
+
+func TestGetScoreBoardWithBiggerGridAndMultipleObstacles(t *testing.T) {
+	grid, _ := game.NewGrid(10)
+	grid = game.AddShip(grid, game.Ship{2, []game.Cell{{1, 2}, {1, 3}}})
+	grid = game.AddShip(grid, game.Ship{3, []game.Cell{{3, 2}, {4, 2}, {5, 2}}})
+	grid = game.AddShip(grid, game.Ship{3, []game.Cell{{5, 6}, {6, 6}, {7, 6}, {8, 6}, {9, 6}}})
+
+	computedShip := game.Ship{2, []game.Cell{}}
+
+	cells := [][]int{
+		{2, 3, 2, 2, 3, 3, 3, 3, 3, 2},
+		{3, 3, 0, 0, 3, 4, 4, 4, 4, 3},
+		{3, 4, 2, 3, 4, 4, 4, 4, 4, 3},
+		{3, 3, 0, 3, 4, 4, 4, 4, 4, 3},
+		{3, 3, 0, 3, 4, 4, 3, 4, 4, 3},
+		{3, 3, 0, 3, 4, 3, 0, 3, 4, 3},
+		{3, 4, 3, 4, 4, 3, 0, 3, 4, 3},
+		{3, 4, 4, 4, 4, 3, 0, 3, 4, 3},
+		{3, 4, 4, 4, 4, 3, 0, 3, 4, 3},
+		{2, 3, 3, 3, 3, 2, 0, 2, 3, 2},
+	}
+
+	expected := &scoreboard.ScoreBoard{10, cells}
+
+	actual, _ := game.GetScoreBoard(grid, computedShip)
+
+	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid with multiple obstacles"))
+	displayScoreBoard(actual, computedShip, grid)
+}
+
 func displayScoreBoard(scoreBoard *scoreboard.ScoreBoard, ship game.Ship, grid game.Grid) {
 	message := scoreboard.ToString(scoreBoard)
 	message += "  "
-	message += strconv.Itoa(ship.Length) + " long ship on 3x3 grid"
-	if len(grid.Ships) > 0 {
-		message += " with obstacle"
+	message += strconv.Itoa(ship.Length) + " long ship on " + strconv.Itoa(grid.Size) + "x" + strconv.Itoa(grid.Size) + " grid"
+	obstaclesCount := len(grid.Ships)
+	if obstaclesCount > 0 {
+		message += " with " + strconv.Itoa(obstaclesCount) + " obstacle"
 	}
 	fmt.Println(message)
 }

--- a/test/battleship/game/scoreboard_test.go
+++ b/test/battleship/game/scoreboard_test.go
@@ -103,7 +103,7 @@ func TestGetScoreBoardWithObstacle(t *testing.T) {
 }
 
 func TestGetScoreBoardWithBiggerGridWithoutObstacle(t *testing.T) {
-	grid, _ := game.NewGrid(10)
+	grid := game.NewGrid(10)
 
 	computedShip := game.Ship{2, []game.Cell{}}
 
@@ -122,14 +122,14 @@ func TestGetScoreBoardWithBiggerGridWithoutObstacle(t *testing.T) {
 
 	expected := &scoreboard.ScoreBoard{10, cells}
 
-	actual, _ := game.GetScoreBoard(grid, computedShip)
+	actual := scoreboard.GetScoreBoard(grid, computedShip)
 
 	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid without obstacle"))
 	displayScoreBoard(actual, computedShip, grid)
 }
 
 func TestGetScoreBoardWithBiggerGridAndOneObstacle(t *testing.T) {
-	grid, _ := game.NewGrid(10)
+	grid := game.NewGrid(10)
 	ship := game.Ship{1, []game.Cell{{1, 2}}}
 	grid = game.AddShip(grid, ship)
 
@@ -150,14 +150,14 @@ func TestGetScoreBoardWithBiggerGridAndOneObstacle(t *testing.T) {
 
 	expected := &scoreboard.ScoreBoard{10, cells}
 
-	actual, _ := game.GetScoreBoard(grid, computedShip)
+	actual := scoreboard.GetScoreBoard(grid, computedShip)
 
 	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid with one obstacle"))
 	displayScoreBoard(actual, computedShip, grid)
 }
 
 func TestGetScoreBoardWithBiggerGridAndMultipleObstacles(t *testing.T) {
-	grid, _ := game.NewGrid(10)
+	grid := game.NewGrid(10)
 	grid = game.AddShip(grid, game.Ship{2, []game.Cell{{1, 2}, {1, 3}}})
 	grid = game.AddShip(grid, game.Ship{3, []game.Cell{{3, 2}, {4, 2}, {5, 2}}})
 	grid = game.AddShip(grid, game.Ship{3, []game.Cell{{5, 6}, {6, 6}, {7, 6}, {8, 6}, {9, 6}}})
@@ -179,7 +179,7 @@ func TestGetScoreBoardWithBiggerGridAndMultipleObstacles(t *testing.T) {
 
 	expected := &scoreboard.ScoreBoard{10, cells}
 
-	actual, _ := game.GetScoreBoard(grid, computedShip)
+	actual := scoreboard.GetScoreBoard(grid, computedShip)
 
 	then.AssertThat(t, actual, is.EqualTo(expected).Reason("Bigger grid with multiple obstacles"))
 	displayScoreBoard(actual, computedShip, grid)


### PR DESCRIPTION
[Trello](https://trello.com/c/fVowfour/3-05-as-peter-i-want-to-know-every-cell-probability-to-have-the-boat-on-it-on-any-size-of-board-and-any-amount-of-obstacles-still)

# TODO
- [X] Score board calculation takes grids with any configuration (size and obstacles/ships)
- [X] Test the score board calculation on bigger grids with/without obstacles

#Result
![last](https://user-images.githubusercontent.com/1423027/93902940-697b5200-fcf8-11ea-9421-100c97225536.png)
