### PR TITLE
[RFR] Fix score board calculation:

### DIFF
--- a/src/battleship/game/grid.go
+++ b/src/battleship/game/grid.go
@@ -2,26 +2,24 @@ package game
 
 // Grid is the board on which the battle ships are positionned
 type Grid struct {
-	Size  int
-	Ships []Ship
-	Cells []Cell
+	Size   int
+	Ships  []Ship
+	Shoots []Cell
 }
 
 // NewGrid create a square grid of the given size
 func NewGrid(gridSize int) Grid {
-	cells := []Cell{}
-
-	for row := 0; row < gridSize; row++ {
-		for column := 0; column < gridSize; column++ {
-			cells = append(cells, Cell{row, column})
-		}
-	}
-
-	return Grid{gridSize, []Ship{}, cells}
+	return Grid{gridSize, []Ship{}, []Cell{}}
 }
 
 // AddShip add a ship to the grid
 func AddShip(grid Grid, ship Ship) Grid {
 	grid.Ships = append(grid.Ships, ship)
+	return grid
+}
+
+// AddShoot add a shoot to the grid
+func AddShoot(grid Grid, shoot Cell) Grid {
+	grid.Shoots = append(grid.Shoots, shoot)
 	return grid
 }

--- a/src/battleship/game/ship.go
+++ b/src/battleship/game/ship.go
@@ -5,32 +5,3 @@ type Ship struct {
 	Length int
 	Cells  []Cell
 }
-
-// ShipsOverlapHorizontally tells if a ship overlaps another one on a particular cell in a row
-func ShipsOverlapHorizontally(ship Ship, gridShip Ship, cell Cell) bool {
-	for _, gridShipCell := range gridShip.Cells {
-		for i := 0; i < ship.Length; i++ {
-			cellToCheck := Cell{cell.Row, cell.Column + i}
-			if cellToCheck == gridShipCell {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// ShipsOverlapVertically tells if a ship overlaps another one on a particular cell in a column
-func ShipsOverlapVertically(ship Ship, gridShip Ship, cell Cell) bool {
-	for _, gridShipCell := range gridShip.Cells {
-		for i := 0; i < ship.Length; i++ {
-			cellToCheck := Cell{cell.Row + i, cell.Column}
-			if cellToCheck == gridShipCell {
-				return true
-			}
-		}
-
-	}
-
-	return false
-}

--- a/src/battleship/scoreboard/scoreboard.go
+++ b/src/battleship/scoreboard/scoreboard.go
@@ -75,9 +75,12 @@ func shipCanBePlacedHorizontally(cell game.Cell, ship game.Ship, grid game.Grid)
 		return false
 	}
 
-	for _, gridShip := range grid.Ships {
-		if game.ShipsOverlapHorizontally(ship, gridShip, cell) {
-			return false
+	for _, shoot := range grid.Shoots {
+		for i := 0; i < ship.Length; i++ {
+			cellToCheck := game.Cell{cell.Row, cell.Column + i}
+			if cellToCheck == shoot {
+				return false
+			}
 		}
 	}
 
@@ -89,9 +92,12 @@ func shipCanBePlacedVertically(cell game.Cell, ship game.Ship, grid game.Grid) b
 		return false
 	}
 
-	for _, gridShip := range grid.Ships {
-		if game.ShipsOverlapVertically(ship, gridShip, cell) {
-			return false
+	for _, shoot := range grid.Shoots {
+		for i := 0; i < ship.Length; i++ {
+			cellToCheck := game.Cell{cell.Row + i, cell.Column}
+			if cellToCheck == shoot {
+				return false
+			}
 		}
 	}
 

--- a/test/battleship/game/scoreboard_test.go
+++ b/test/battleship/game/scoreboard_test.go
@@ -78,13 +78,12 @@ func TestGetScoreBoardWithTooLongShip(t *testing.T) {
 }
 
 func TestGetScoreBoardWithObstacle(t *testing.T) {
-	// Given a grid with a 1 cell long ship on it (the obstacle)
+	// Given a grid with an obstacle
 	// and considering a 2 cells long ship
 	grid := game.NewGrid(3)
-	ship := game.Ship{1, []game.Cell{{1, 2}}}
-	grid = game.AddShip(grid, ship)
+	grid = game.AddShoot(grid, game.Cell{1, 2})
 
-	computedShip := game.Ship{2, []game.Cell{}}
+	ship := game.Ship{2, []game.Cell{}}
 
 	cells := [][]int{
 		{2, 3, 1},
@@ -94,12 +93,12 @@ func TestGetScoreBoardWithObstacle(t *testing.T) {
 
 	expected := &scoreboard.ScoreBoard{3, cells}
 
-	// When computing possible positions of the second ship
-	actual := scoreboard.GetScoreBoard(grid, computedShip)
+	// When computing possible positions of the ship
+	actual := scoreboard.GetScoreBoard(grid, ship)
 
 	// Then the resulting score board should equals the expected one
 	then.AssertThat(t, actual, is.EqualTo(expected).Reason("There is an obstacle on cell 1:2"))
-	displayScoreBoard(actual, computedShip, grid)
+	displayScoreBoard(actual, ship, grid)
 }
 
 func displayScoreBoard(scoreBoard *scoreboard.ScoreBoard, ship game.Ship, grid game.Grid) {


### PR DESCRIPTION
This PR is a correction of the previous merged PR linked to this ticket: [Trello](https://trello.com/c/3CB7wR49/2-05-as-peter-given-a-small-board-with-a-single-destroyer-and-one-obstacle-i-want-to-know-every-cell-probability-to-have-the-boat)

I was considering the opponent ships as obstacles instead of the shoots I already made.

When I am playing on my turn, the algorithm should take the shoots I made and propose to me the available positions of the possibly remaining ships of my opponent.

# TODO
- [X] When checking available positions (and comparing cells) the algo should compare shoots and tested cell
- [X] Adjust test to reflect the change

# Result
![last](https://user-images.githubusercontent.com/1423027/93998988-916cc300-fd95-11ea-924c-d8e409354309.png)
