### PR TITLE
[RFR] Depreacte repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # battleship-go
 
-Code moved to [marmelab/battleship-symfony](https://github.com/marmelab/battleship-symfony).
+<table>
+        <tr>
+            <td><img width="40" src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/stop.svg" alt="deprecated" /></td>
+            <td><strong>Archived Repository</strong><br />
+            This code has been moved to [marmelab/battleship-symfony](https://github.com/marmelab/battleship-symfony).
+        </td>
+        </tr>
+</table>
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # battleship-go
 
+Code moved to [marmelab/battleship-symfony](https://github.com/marmelab/battleship-symfony).
+
 ## Install
 
 Install docker

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
         <tr>
             <td><img width="40" src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/stop.svg" alt="deprecated" /></td>
             <td><strong>Archived Repository</strong><br />
-            This code has been moved to [marmelab/battleship-symfony](https://github.com/marmelab/battleship-symfony).
+            This code has been moved to <a href="https://github.com/marmelab/battleship-symfony">marmelab/battleship-symfony</a>.
         </td>
         </tr>
 </table>


### PR DESCRIPTION
Repository depreacted in favor to [marmelab/battleship-symfony](https://github.com/marmelab/battleship-symfony)

## Todo

- [x] Add a deprecation warning in the README